### PR TITLE
Add FastAPI-based SRT voiceover generation service

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ Among our currently benchmarked agents, AutoGPT scores the best. This will chang
 
 - **To activate the best agent** follow the guide [here](https://github.com/Significant-Gravitas/AutoGPT/blob/master/autogpts/autogpt/README.md).
 
+## 📦 Downloading the Codex-generated project
+
+Need an archive of the project that Codex produced? Run the helper script from the repository root to create a zip file that skips version-control metadata and caches:
+
+```bash
+python package_codex_project.py --output autogpt_codex_project.zip
+```
+
+The command prints the location of the archive once it is created, so you can download it directly.
+
 Want to build your own groundbreaking agent using AutoGPT? 🛠️ There are three major components to focus on:
 
 ### 🏗️ the Forge

--- a/apps/srt_voice_service/app.py
+++ b/apps/srt_voice_service/app.py
@@ -1,0 +1,150 @@
+"""FastAPI application for generating multi-speaker voiceovers from SRT files."""
+
+from __future__ import annotations
+
+import json
+import threading
+import uuid
+from pathlib import Path
+from typing import Any, Dict
+
+from fastapi import BackgroundTasks, FastAPI, File, Form, HTTPException, Request, UploadFile
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from .services.audio_stitcher import AudioTimelineBuilder
+from .services.config import GenerationConfig
+from .services.srt_parser import parse_srt
+from .services.voice_provider import MockVoiceProvider, ThirdPartyVoiceProvider, VoiceProvider
+
+APP_DIR = Path(__file__).resolve().parent
+GENERATED_DIR = APP_DIR / "generated"
+GENERATED_DIR.mkdir(parents=True, exist_ok=True)
+
+app = FastAPI(title="SRT Voice Composer")
+app.mount("/static", StaticFiles(directory=APP_DIR / "static"), name="static")
+templates = Jinja2Templates(directory=str(APP_DIR / "templates"))
+
+_tasks_lock = threading.Lock()
+_tasks: Dict[str, Dict[str, Any]] = {}
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request) -> HTMLResponse:
+    """Render the main UI."""
+    return templates.TemplateResponse("index.html", {"request": request})
+
+
+def _load_generation_config(raw_config: str | None) -> GenerationConfig:
+    if not raw_config:
+        raise HTTPException(status_code=400, detail="Missing role configuration JSON.")
+
+    try:
+        parsed = json.loads(raw_config)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid JSON payload: {exc}") from exc
+
+    return GenerationConfig.from_dict(parsed)
+
+
+def _get_voice_provider(config: GenerationConfig) -> VoiceProvider:
+    provider_conf = config.provider
+    if provider_conf and provider_conf.base_url:
+        return ThirdPartyVoiceProvider(provider_conf)
+    return MockVoiceProvider()
+
+
+def _update_task(job_id: str, **updates: Any) -> None:
+    with _tasks_lock:
+        task = _tasks.setdefault(job_id, {"status": "queued", "progress": 0.0})
+        task.update(updates)
+
+
+def _process_generation(job_id: str, srt_payload: bytes, config: GenerationConfig) -> None:
+    try:
+        _update_task(job_id, status="processing", progress=0.0, message="Parsing subtitles")
+        subtitles = list(parse_srt(srt_payload.decode("utf-8")))
+        if not subtitles:
+            raise ValueError("The provided SRT file does not contain any dialogue entries.")
+
+        provider = _get_voice_provider(config)
+        total_segments = len(subtitles)
+        timeline = AudioTimelineBuilder()
+
+        for idx, subtitle in enumerate(subtitles, start=1):
+            role_config = config.roles.get(subtitle.speaker)
+            if not role_config:
+                raise ValueError(
+                    f"No voice configuration found for speaker '{subtitle.speaker}'. "
+                    "Please add a mapping in the role configuration."
+                )
+
+            _update_task(
+                job_id,
+                message=f"Synthesizing voice for {subtitle.speaker}",
+                progress=round((idx - 1) / total_segments * 100, 2),
+            )
+
+            audio_bytes = provider.synthesize(subtitle.text, role_config)
+            timeline.add_segment(subtitle, audio_bytes, role_config.audio_format)
+
+        output_path = GENERATED_DIR / f"{job_id}.mp3"
+        _update_task(job_id, message="Mixing audio tracks")
+        exported = timeline.export(output_path)
+
+        _update_task(
+            job_id,
+            status="completed",
+            progress=100.0,
+            message="Voiceover successfully generated",
+            download_url=f"/download/{job_id}",
+            duration_seconds=exported.duration_seconds,
+        )
+    except Exception as exc:  # pylint: disable=broad-except
+        _update_task(job_id, status="failed", message=str(exc))
+
+
+@app.post("/generate")
+async def generate_voiceover(
+    background_tasks: BackgroundTasks,
+    file: UploadFile = File(...),
+    config: str = Form(...),
+) -> JSONResponse:
+    """Accept SRT + configuration and start the generation job."""
+    srt_payload = await file.read()
+    if not srt_payload:
+        raise HTTPException(status_code=400, detail="Uploaded SRT file was empty.")
+
+    job_id = str(uuid.uuid4())
+    generation_config = _load_generation_config(config)
+
+    with _tasks_lock:
+        _tasks[job_id] = {"status": "queued", "progress": 0.0, "message": "Waiting to start"}
+
+    background_tasks.add_task(_process_generation, job_id, srt_payload, generation_config)
+    return JSONResponse({"job_id": job_id})
+
+
+@app.get("/status/{job_id}")
+async def job_status(job_id: str) -> JSONResponse:
+    with _tasks_lock:
+        task = _tasks.get(job_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return JSONResponse(task)
+
+
+@app.get("/download/{job_id}")
+async def download(job_id: str) -> FileResponse:
+    output_path = GENERATED_DIR / f"{job_id}.mp3"
+    if not output_path.exists():
+        raise HTTPException(status_code=404, detail="Generated audio not found")
+    return FileResponse(
+        output_path,
+        media_type="audio/mpeg",
+        filename=f"voiceover-{job_id}.mp3",
+    )
+
+
+__all__ = ["app"]

--- a/apps/srt_voice_service/services/audio_stitcher.py
+++ b/apps/srt_voice_service/services/audio_stitcher.py
@@ -39,8 +39,16 @@ class AudioTimelineBuilder:
         if not self._entries:
             raise ValueError("No audio segments were added to the timeline.")
 
-        total_duration = max(entry.end for entry, _ in self._entries)
         buffer = timedelta(seconds=1)
+        total_duration = timedelta()
+        for subtitle, segment in self._entries:
+            subtitle_window = subtitle.end - subtitle.start
+            segment_duration = timedelta(milliseconds=len(segment))
+            effective_duration = max(subtitle_window, segment_duration)
+            segment_end = subtitle.start + effective_duration
+            if segment_end > total_duration:
+                total_duration = segment_end
+
         total_ms = int((total_duration + buffer).total_seconds() * 1000)
         timeline = AudioSegment.silent(duration=total_ms)
 

--- a/apps/srt_voice_service/services/audio_stitcher.py
+++ b/apps/srt_voice_service/services/audio_stitcher.py
@@ -1,0 +1,53 @@
+"""Utilities for combining voice segments into a single timeline."""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+from datetime import timedelta
+from pathlib import Path
+from typing import List, Tuple
+
+from pydub import AudioSegment
+
+from .srt_parser import SubtitleSegment
+
+
+@dataclass(slots=True)
+class ExportedAudio:
+    """Details about a rendered audio file."""
+
+    path: Path
+    duration_seconds: float
+
+
+class AudioTimelineBuilder:
+    """Accumulates subtitle-aligned audio segments and mixes them into a single file."""
+
+    def __init__(self) -> None:
+        self._entries: List[Tuple[SubtitleSegment, AudioSegment]] = []
+
+    def add_segment(self, subtitle: SubtitleSegment, audio_bytes: bytes, audio_format: str) -> None:
+        """Add an audio clip aligned with a subtitle segment."""
+
+        if not audio_bytes:
+            raise ValueError("Received empty audio payload from provider.")
+        segment = AudioSegment.from_file(io.BytesIO(audio_bytes), format=audio_format)
+        self._entries.append((subtitle, segment))
+
+    def export(self, output_path: Path) -> ExportedAudio:
+        if not self._entries:
+            raise ValueError("No audio segments were added to the timeline.")
+
+        total_duration = max(entry.end for entry, _ in self._entries)
+        buffer = timedelta(seconds=1)
+        total_ms = int((total_duration + buffer).total_seconds() * 1000)
+        timeline = AudioSegment.silent(duration=total_ms)
+
+        for subtitle, segment in self._entries:
+            start_ms = int(subtitle.start.total_seconds() * 1000)
+            timeline = timeline.overlay(segment, position=start_ms)
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        timeline.export(output_path, format="mp3")
+        return ExportedAudio(path=output_path, duration_seconds=timeline.duration_seconds)

--- a/apps/srt_voice_service/services/config.py
+++ b/apps/srt_voice_service/services/config.py
@@ -1,0 +1,81 @@
+"""Configuration models for the SRT voice generation service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Mapping, Optional
+
+
+@dataclass(slots=True)
+class ProviderConfig:
+    """Configuration for the third-party text-to-speech provider."""
+
+    base_url: str
+    api_key: Optional[str] = None
+    timeout_seconds: float = 30.0
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, object]) -> "ProviderConfig":
+        base_url = str(payload.get("base_url", "")).strip()
+        if not base_url:
+            raise ValueError("Provider configuration requires a 'base_url'.")
+        api_key = payload.get("api_key")
+        timeout = float(payload.get("timeout_seconds", 30.0))
+        return cls(base_url=base_url, api_key=str(api_key) if api_key else None, timeout_seconds=timeout)
+
+
+@dataclass(slots=True)
+class RoleConfig:
+    """Voice configuration for a single speaker."""
+
+    voice_id: str
+    audio_format: str = "mp3"
+    speaking_rate: float = 1.0
+    pitch: float = 0.0
+    extra: Dict[str, object] = field(default_factory=dict)
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, object]) -> "RoleConfig":
+        voice_id = str(payload.get("voice_id", "")).strip()
+        if not voice_id:
+            raise ValueError("Each role must define a non-empty 'voice_id'.")
+        audio_format = str(payload.get("audio_format", "mp3"))
+        speaking_rate = float(payload.get("speaking_rate", 1.0))
+        pitch = float(payload.get("pitch", 0.0))
+        extra = {
+            key: value
+            for key, value in payload.items()
+            if key not in {"voice_id", "audio_format", "speaking_rate", "pitch"}
+        }
+        return cls(
+            voice_id=voice_id,
+            audio_format=audio_format,
+            speaking_rate=speaking_rate,
+            pitch=pitch,
+            extra=extra,
+        )
+
+
+@dataclass(slots=True)
+class GenerationConfig:
+    """Aggregate configuration used during a voice generation job."""
+
+    roles: Dict[str, RoleConfig]
+    provider: Optional[ProviderConfig] = None
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> "GenerationConfig":
+        raw_roles = payload.get("roles")
+        if not isinstance(raw_roles, Mapping):
+            raise ValueError("Configuration must contain a 'roles' mapping of speaker names to settings.")
+
+        roles = {name: RoleConfig.from_mapping(config) for name, config in raw_roles.items()}
+
+        provider_config: Optional[ProviderConfig] = None
+        raw_provider = payload.get("provider")
+        if isinstance(raw_provider, Mapping):
+            base_url = str(raw_provider.get("base_url", "")).strip()
+            if base_url:
+                provider_config = ProviderConfig.from_mapping(raw_provider)
+
+        return cls(roles=roles, provider=provider_config)

--- a/apps/srt_voice_service/services/srt_parser.py
+++ b/apps/srt_voice_service/services/srt_parser.py
@@ -1,0 +1,44 @@
+"""Utilities for parsing SRT subtitle files."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Iterator
+
+import srt
+
+
+@dataclass(slots=True)
+class SubtitleSegment:
+    """Lightweight representation of a single SRT cue."""
+
+    speaker: str
+    text: str
+    start: timedelta
+    end: timedelta
+
+
+def _split_speaker_and_text(payload: str) -> tuple[str, str]:
+    if ":" in payload:
+        potential_speaker, remainder = payload.split(":", 1)
+        speaker = potential_speaker.strip()
+        if speaker and speaker.replace(" ", "").isalpha():
+            return speaker, remainder.strip()
+    return "Narrator", payload.strip()
+
+
+def parse_srt(raw_content: str) -> Iterator[SubtitleSegment]:
+    """Yield subtitle segments from raw SRT content."""
+
+    for entry in srt.parse(raw_content):
+        text = entry.content.strip()
+        if not text:
+            continue
+        speaker, content = _split_speaker_and_text(text)
+        yield SubtitleSegment(
+            speaker=speaker,
+            text=content,
+            start=entry.start,
+            end=entry.end,
+        )

--- a/apps/srt_voice_service/services/voice_provider.py
+++ b/apps/srt_voice_service/services/voice_provider.py
@@ -1,0 +1,81 @@
+"""Voice provider interfaces used for synthesizing speech."""
+
+from __future__ import annotations
+
+import base64
+import io
+from abc import ABC, abstractmethod
+from typing import Dict
+
+import requests
+from pydub.generators import Sine
+
+from .config import ProviderConfig, RoleConfig
+
+
+class VoiceProvider(ABC):
+    """Abstract base class for text-to-speech providers."""
+
+    @abstractmethod
+    def synthesize(self, text: str, role: RoleConfig) -> bytes:
+        """Generate audio bytes for the supplied text."""
+
+
+class ThirdPartyVoiceProvider(VoiceProvider):
+    """Calls an external HTTP API to synthesize speech."""
+
+    def __init__(self, config: ProviderConfig) -> None:
+        self._config = config
+
+    def synthesize(self, text: str, role: RoleConfig) -> bytes:
+        payload: Dict[str, object] = {
+            "voice_id": role.voice_id,
+            "text": text,
+            "speaking_rate": role.speaking_rate,
+            "pitch": role.pitch,
+        }
+        payload.update(role.extra)
+
+        headers = {"Content-Type": "application/json"}
+        if self._config.api_key:
+            headers["Authorization"] = f"Bearer {self._config.api_key}"
+
+        response = requests.post(
+            self._config.base_url.rstrip("/") + "/synthesize",
+            json=payload,
+            headers=headers,
+            timeout=self._config.timeout_seconds,
+        )
+        if response.status_code >= 400:
+            raise RuntimeError(
+                f"Voice provider returned HTTP {response.status_code}: {response.text}"
+            )
+
+        content_type = response.headers.get("Content-Type", "")
+        if content_type.startswith("application/json"):
+            body = response.json()
+            audio_payload = body.get("audio")
+            if not isinstance(audio_payload, str):
+                raise RuntimeError("Voice provider JSON response did not contain 'audio' field.")
+            return base64.b64decode(audio_payload)
+
+        return response.content
+
+
+class MockVoiceProvider(VoiceProvider):
+    """Generates placeholder audio tones for development environments."""
+
+    def synthesize(self, text: str, role: RoleConfig) -> bytes:
+        words = max(len(text.split()), 1)
+        duration_ms = max(350, words * 320)
+        frequency = 300 + (abs(hash(role.voice_id)) % 300)
+        segment = (
+            Sine(frequency)
+            .to_audio_segment(duration=duration_ms)
+            .fade_in(40)
+            .fade_out(80)
+        )
+        buffer = io.BytesIO()
+        export_format = role.audio_format or "mp3"
+        segment.export(buffer, format=export_format)
+        return buffer.getvalue()

--- a/apps/srt_voice_service/static/app.js
+++ b/apps/srt_voice_service/static/app.js
@@ -1,0 +1,87 @@
+const form = document.getElementById("generation-form");
+const statusPanel = document.getElementById("status-panel");
+const progressBar = document.getElementById("progress-bar");
+const statusMessage = document.getElementById("status-message");
+const downloadLink = document.getElementById("download-link");
+
+let pollTimer = null;
+
+function resetStatus() {
+  if (pollTimer) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
+  progressBar.style.width = "0%";
+  statusMessage.textContent = "";
+  downloadLink.classList.add("hidden");
+  downloadLink.innerHTML = "";
+}
+
+async function pollStatus(jobId) {
+  pollTimer = setInterval(async () => {
+    try {
+      const response = await fetch(`/status/${jobId}`);
+      if (!response.ok) {
+        throw new Error("无法获取任务状态");
+      }
+      const data = await response.json();
+      progressBar.style.width = `${Math.floor(data.progress || 0)}%`;
+      statusMessage.textContent = data.message || "处理中";
+
+      if (data.status === "completed") {
+        clearInterval(pollTimer);
+        pollTimer = null;
+        if (data.download_url) {
+          downloadLink.innerHTML = `<a href="${data.download_url}" download>下载生成的 MP3</a>`;
+          downloadLink.classList.remove("hidden");
+        }
+      } else if (data.status === "failed") {
+        clearInterval(pollTimer);
+        pollTimer = null;
+        statusMessage.textContent = `任务失败：${data.message || "未知错误"}`;
+      }
+    } catch (error) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+      statusMessage.textContent = `状态更新失败：${error.message}`;
+    }
+  }, 1500);
+}
+
+form.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  resetStatus();
+
+  const fileInput = document.getElementById("srt-file");
+  const configInput = document.getElementById("config-json");
+
+  if (!fileInput.files.length) {
+    statusMessage.textContent = "请先选择字幕文件。";
+    return;
+  }
+
+  statusPanel.classList.remove("hidden");
+  statusMessage.textContent = "正在上传并创建任务...";
+
+  const formData = new FormData();
+  formData.append("file", fileInput.files[0]);
+  formData.append("config", configInput.value);
+
+  try {
+    const response = await fetch("/generate", {
+      method: "POST",
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(errorText || "提交失败");
+    }
+
+    const data = await response.json();
+    statusMessage.textContent = "任务已创建，开始处理...";
+    pollStatus(data.job_id);
+  } catch (error) {
+    statusMessage.textContent = `提交失败：${error.message}`;
+  }
+});

--- a/apps/srt_voice_service/templates/index.html
+++ b/apps/srt_voice_service/templates/index.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="zh">
+  <head>
+    <meta charset="UTF-8" />
+    <title>多角色语音合成</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css" />
+    <style>
+      body {
+        padding: 2rem;
+      }
+      textarea {
+        min-height: 200px;
+        font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+      }
+      #status-panel {
+        margin-top: 1.5rem;
+      }
+      .hidden {
+        display: none;
+      }
+      .progress-bar {
+        height: 12px;
+        background-color: var(--primary);
+        transition: width 0.3s ease;
+      }
+      .progress-track {
+        background-color: rgba(0, 0, 0, 0.1);
+        width: 100%;
+        height: 12px;
+        border-radius: 10px;
+        overflow: hidden;
+      }
+      footer {
+        margin-top: 3rem;
+        font-size: 0.9rem;
+        color: #555;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <h1>多角色语音播客生成器</h1>
+      <p>
+        上传一份包含角色对白的 <code>.srt</code> 字幕文件，并为每个角色指定第三方语音接口的参数，系统会按照时间轴合成自然流畅的多角色语音文件。
+      </p>
+      <form id="generation-form">
+        <label for="srt-file">字幕文件（SRT）</label>
+        <input type="file" id="srt-file" name="file" accept=".srt" required />
+
+        <label for="config-json">角色与接口配置（JSON）</label>
+        <textarea id="config-json" name="config" spellcheck="false" required>{
+  "provider": {
+    "base_url": "https://api.example.com/tts",
+    "api_key": "YOUR_TOKEN"
+  },
+  "roles": {
+    "Alice": { "voice_id": "voice_a", "audio_format": "mp3" },
+    "Bob": { "voice_id": "voice_b", "audio_format": "mp3" }
+  }
+}</textarea>
+
+        <button type="submit">生成语音</button>
+      </form>
+
+      <section id="status-panel" class="hidden">
+        <h2>生成进度</h2>
+        <div class="progress-track">
+          <div id="progress-bar" class="progress-bar" style="width: 0%"></div>
+        </div>
+        <p id="status-message"></p>
+        <p id="download-link" class="hidden"></p>
+      </section>
+    </main>
+
+    <footer>
+      <p>提示：SRT 文本中需使用 <code>角色名: 台词</code> 的格式来识别不同角色。</p>
+    </footer>
+
+    <script src="/static/app.js"></script>
+  </body>
+</html>

--- a/docs/srt_voice_service.md
+++ b/docs/srt_voice_service.md
@@ -1,0 +1,74 @@
+# 多角色字幕语音合成服务
+
+该服务提供一个简单的 Web 界面，可上传包含角色台词的 `.srt` 字幕文件，并基于第三方语音合成接口，将不同角色的语音片段生成并按时间轴拼接成一段可下载的 MP3 文件。非常适合播客制作、视频配音或教学场景。
+
+## 功能概述
+
+- **SRT 解析**：自动识别字幕中的时间轴以及 `角色名: 对白` 格式的发言者。
+- **多角色语音生成**：为每个角色配置不同的第三方语音合成参数；未配置时使用内置的本地占位音频生成器（便于开发环境调试）。
+- **时间线拼接**：将单句语音片段按照字幕时间码对齐并合成完整音频。
+- **任务进度**：前端轮询后端任务状态，显示生成进度、状态说明与下载链接。
+
+## 目录结构
+
+```text
+apps/srt_voice_service/
+├── app.py                 # FastAPI 入口
+├── services/
+│   ├── audio_stitcher.py  # 音频拼接工具
+│   ├── config.py          # 角色及服务端配置模型
+│   ├── srt_parser.py      # 字幕解析逻辑
+│   └── voice_provider.py  # 第三方接口调用与本地占位实现
+├── static/
+│   └── app.js             # 前端交互脚本
+└── templates/
+    └── index.html         # Web UI
+```
+
+生成的 MP3 文件默认保存在 `apps/srt_voice_service/generated/` 目录中。
+
+## 运行步骤
+
+1. 安装依赖（确保已安装 `ffmpeg` 以便导出 MP3）：
+
+   ```bash
+   poetry install
+   ```
+
+2. 启动服务：
+
+   ```bash
+   uvicorn apps.srt_voice_service.app:app --reload
+   ```
+
+3. 访问 `http://127.0.0.1:8000` 上传 SRT 并配置角色参数。
+
+## 配置说明
+
+- **provider.base_url**：第三方语音合成接口的基础 URL，服务会在其后追加 `/synthesize` 路径。
+- **provider.api_key**：若接口需要鉴权，服务会以 `Bearer` 方式写入 `Authorization` 请求头。
+- **roles**：以角色名为键，配置 `voice_id`、语速、音调等参数，其余字段会透传给第三方接口。
+
+示例：
+
+```json
+{
+  "provider": {
+    "base_url": "https://api.example.com/tts",
+    "api_key": "YOUR_TOKEN"
+  },
+  "roles": {
+    "Alice": { "voice_id": "voice_a", "speaking_rate": 1.05 },
+    "Bob": { "voice_id": "voice_b", "pitch": -1.5 }
+  }
+}
+```
+
+当未提供 `provider.base_url` 时，后端会使用 `MockVoiceProvider` 生成占位音频，便于快速预览时间轴与拼接效果。
+
+## 注意事项
+
+- SRT 台词需采用 `角色名: 内容` 的格式才能正确识别说话人。
+- 第三方接口返回的内容可以是 MP3 等音频二进制流，或包含 Base64 字段的 JSON 数据。
+- 若使用自定义音频格式，务必在角色配置中通过 `audio_format` 指定对应的格式，以便正确解析。
+

--- a/package_codex_project.py
+++ b/package_codex_project.py
@@ -1,0 +1,102 @@
+"""Utility script to package the current AutoGPT workspace as a zip archive.
+
+This helper focuses on the Codex-generated project contained in the repository. It
+creates a deterministic archive that skips build artefacts and version-control
+folders so the resulting download only contains the relevant source files.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+from typing import Iterator
+import zipfile
+
+EXCLUDE_DIRS = {
+    ".git",
+    "__pycache__",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".venv",
+    "venv",
+    "node_modules",
+}
+
+EXCLUDE_FILES = {
+    ".DS_Store",
+}
+
+
+def iter_files(root: Path) -> Iterator[Path]:
+    """Yield all files under *root* that are not excluded."""
+    for dirpath, dirnames, filenames in os.walk(root):
+        path_obj = Path(dirpath)
+
+        # Prevent os.walk from descending into excluded directories by mutating
+        # dirnames in-place.
+        dirnames[:] = [d for d in dirnames if d not in EXCLUDE_DIRS]
+
+        for filename in filenames:
+            if filename in EXCLUDE_FILES:
+                continue
+
+            file_path = path_obj / filename
+            if any(part in EXCLUDE_DIRS for part in file_path.relative_to(root).parts):
+                continue
+
+            yield file_path
+
+
+def create_archive(root: Path, output: Path) -> None:
+    """Create a zip archive containing the repository contents."""
+    root = root.resolve()
+    output = output.resolve()
+
+    if output.exists():
+        output.unlink()
+
+    try:
+        output_relative = output.relative_to(root)
+    except ValueError:
+        output_relative = None
+
+    seen_paths: set[Path] = set()
+
+    with zipfile.ZipFile(output, "w", zipfile.ZIP_DEFLATED) as archive:
+        for file_path in iter_files(root):
+            relative_path = file_path.resolve().relative_to(root)
+            if output_relative is not None and relative_path == output_relative:
+                # Skip the archive itself when it lives inside the repository.
+                continue
+            if relative_path in seen_paths:
+                continue
+            seen_paths.add(relative_path)
+            archive.write(file_path, arcname=str(relative_path))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Package the Codex-generated AutoGPT project into a zip archive.",
+    )
+    parser.add_argument(
+        "--output",
+        default="autogpt_codex_project.zip",
+        help="Destination path for the generated zip file (default: %(default)s)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    root = Path(__file__).resolve().parent
+    output = Path(args.output)
+    if not output.is_absolute():
+        output = root / output
+
+    create_archive(root, output)
+    print(f"Archive written to {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,13 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
+fastapi = "^0.110.0"
+jinja2 = "^3.1.3"
+pydub = "^0.25.1"
+python-multipart = "^0.0.9"
+requests = "^2.31.0"
+srt = "^3.5.3"
+uvicorn = {extras = ["standard"], version = "^0.27.1"}
 
 
 [build-system]


### PR DESCRIPTION
## Summary
- add a FastAPI application that ingests SRT subtitles, calls a third-party TTS provider per speaker, and stitches the clips into a single MP3
- provide supporting services for configuration parsing, audio timeline mixing, and a web UI for uploading subtitles, configuring roles, and tracking progress
- document the workflow and declare the required dependencies for running the service

## Testing
- python -m compileall apps/srt_voice_service

------
https://chatgpt.com/codex/tasks/task_e_68d8a559bfe08332ad1dbe63ef1cd2bd