### PR TITLE
Extend voice service with transcription and transcript management

### DIFF
--- a/apps/srt_voice_service/app.py
+++ b/apps/srt_voice_service/app.py
@@ -1,0 +1,327 @@
+"""FastAPI application for generating multi-speaker voiceovers from SRT files."""
+
+from __future__ import annotations
+
+import json
+import threading
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional
+
+from fastapi import BackgroundTasks, FastAPI, File, Form, HTTPException, Request, UploadFile
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from .services.audio_stitcher import AudioTimelineBuilder
+from .services.config import GenerationConfig, ProviderConfig
+from .services.speech_recognizer import (
+    MockSpeechRecognizer,
+    SpeechRecognizer,
+    ThirdPartySpeechRecognizer,
+    segments_to_srt,
+    serialize_segments,
+)
+from .services.srt_parser import parse_srt
+from .services.voice_provider import MockVoiceProvider, ThirdPartyVoiceProvider, VoiceProvider
+
+APP_DIR = Path(__file__).resolve().parent
+GENERATED_DIR = APP_DIR / "generated"
+TRANSCRIPTS_DIR = APP_DIR / "transcripts"
+GENERATED_DIR.mkdir(parents=True, exist_ok=True)
+TRANSCRIPTS_DIR.mkdir(parents=True, exist_ok=True)
+
+app = FastAPI(title="SRT Voice Composer")
+app.mount("/static", StaticFiles(directory=APP_DIR / "static"), name="static")
+templates = Jinja2Templates(directory=str(APP_DIR / "templates"))
+
+_tasks_lock = threading.Lock()
+_tasks: Dict[str, Dict[str, Any]] = {}
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request) -> HTMLResponse:
+    """Render the main UI."""
+    return templates.TemplateResponse("index.html", {"request": request})
+
+
+def _load_generation_config(raw_config: str | None) -> GenerationConfig:
+    if not raw_config:
+        raise HTTPException(status_code=400, detail="Missing role configuration JSON.")
+
+    try:
+        parsed = json.loads(raw_config)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid JSON payload: {exc}") from exc
+
+    return GenerationConfig.from_dict(parsed)
+
+
+def _load_provider_config(payload: Mapping[str, object] | None) -> Optional[ProviderConfig]:
+    if not payload:
+        return None
+    try:
+        return ProviderConfig.from_mapping(payload)
+    except Exception as exc:  # pylint: disable=broad-except
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+def _load_recognizer(raw_config: str | None) -> SpeechRecognizer:
+    provider_config: Optional[ProviderConfig] = None
+    if raw_config:
+        try:
+            parsed = json.loads(raw_config)
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            raise HTTPException(status_code=400, detail=f"Invalid JSON payload: {exc}") from exc
+
+        provider_payload = None
+        if isinstance(parsed, Mapping):
+            raw_provider = parsed.get("provider")
+            if isinstance(raw_provider, Mapping):
+                provider_payload = raw_provider
+        provider_config = _load_provider_config(provider_payload)
+
+    if provider_config:
+        return ThirdPartySpeechRecognizer(provider_config)
+    return MockSpeechRecognizer()
+
+
+def _get_voice_provider(config: GenerationConfig) -> VoiceProvider:
+    provider_conf = config.provider
+    if provider_conf and provider_conf.base_url:
+        return ThirdPartyVoiceProvider(provider_conf)
+    return MockVoiceProvider()
+
+
+def _update_task(job_id: str, **updates: Any) -> None:
+    with _tasks_lock:
+        task = _tasks.setdefault(job_id, {"status": "queued", "progress": 0.0})
+        task.update(updates)
+
+
+def _process_generation(job_id: str, srt_payload: bytes, config: GenerationConfig) -> None:
+    try:
+        _update_task(job_id, status="processing", progress=0.0, message="Parsing subtitles")
+        subtitles = list(parse_srt(srt_payload.decode("utf-8")))
+        if not subtitles:
+            raise ValueError("The provided SRT file does not contain any dialogue entries.")
+
+        provider = _get_voice_provider(config)
+        total_segments = len(subtitles)
+        timeline = AudioTimelineBuilder()
+
+        for idx, subtitle in enumerate(subtitles, start=1):
+            role_config = config.resolve_role(subtitle.speaker, subtitle.gender)
+
+            _update_task(
+                job_id,
+                message=f"Synthesizing voice for {subtitle.speaker}",
+                progress=round((idx - 1) / total_segments * 100, 2),
+            )
+
+            audio_bytes = provider.synthesize(subtitle.text, role_config)
+            timeline.add_segment(subtitle, audio_bytes, role_config.audio_format)
+
+        output_path = GENERATED_DIR / f"{job_id}.mp3"
+        _update_task(job_id, message="Mixing audio tracks")
+        exported = timeline.export(output_path)
+
+        _update_task(
+            job_id,
+            status="completed",
+            progress=100.0,
+            message="Voiceover successfully generated",
+            download_url=f"/download/{job_id}",
+            duration_seconds=exported.duration_seconds,
+        )
+    except Exception as exc:  # pylint: disable=broad-except
+        _update_task(job_id, status="failed", message=str(exc))
+
+
+def _transcript_metadata_path(transcript_id: str) -> Path:
+    return TRANSCRIPTS_DIR / f"{transcript_id}.json"
+
+
+def _transcript_file_path(transcript_id: str) -> Path:
+    return TRANSCRIPTS_DIR / f"{transcript_id}.srt"
+
+
+def _save_transcript(
+    transcript_id: str,
+    original_filename: str,
+    srt_text: str,
+    segments: list[dict[str, object]],
+) -> dict[str, Any]:
+    srt_path = _transcript_file_path(transcript_id)
+    metadata_path = _transcript_metadata_path(transcript_id)
+    srt_path.write_text(srt_text, encoding="utf-8")
+
+    duration = max((segment.get("end", 0.0) for segment in segments), default=0.0)
+    speakers = sorted({str(segment.get("speaker", "Narrator")) for segment in segments})
+    metadata = {
+        "id": transcript_id,
+        "original_filename": original_filename,
+        "created_at": datetime.utcnow().isoformat() + "Z",
+        "segment_count": len(segments),
+        "speakers": speakers,
+        "duration_seconds": duration,
+        "emotions": sorted({segment.get("emotion") for segment in segments if segment.get("emotion")}),
+        "tones": sorted({segment.get("tone") for segment in segments if segment.get("tone")}),
+        "srt_path": str(srt_path.relative_to(APP_DIR)),
+    }
+    metadata_path.write_text(json.dumps(metadata, ensure_ascii=False, indent=2), encoding="utf-8")
+    return metadata
+
+
+def _load_transcript_metadata(transcript_id: str) -> dict[str, Any]:
+    metadata_path = _transcript_metadata_path(transcript_id)
+    if not metadata_path.exists():
+        raise HTTPException(status_code=404, detail="Transcript metadata not found")
+    return json.loads(metadata_path.read_text(encoding="utf-8"))
+
+
+def _load_transcript_srt(transcript_id: str) -> str:
+    srt_path = _transcript_file_path(transcript_id)
+    if not srt_path.exists():
+        raise HTTPException(status_code=404, detail="Transcript SRT file not found")
+    return srt_path.read_text(encoding="utf-8")
+
+
+def _list_transcripts() -> list[dict[str, Any]]:
+    transcripts: list[dict[str, Any]] = []
+    for metadata_file in TRANSCRIPTS_DIR.glob("*.json"):
+        try:
+            metadata = json.loads(metadata_file.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            continue
+        transcripts.append(metadata)
+
+    transcripts.sort(key=lambda item: item.get("created_at", ""), reverse=True)
+    for transcript in transcripts:
+        transcript["download_url"] = f"/transcripts/{transcript['id']}/download"
+    return transcripts
+
+
+@app.post("/generate")
+async def generate_voiceover(
+    background_tasks: BackgroundTasks,
+    file: UploadFile = File(...),
+    config: str = Form(...),
+) -> JSONResponse:
+    """Accept SRT + configuration and start the generation job."""
+    srt_payload = await file.read()
+    if not srt_payload:
+        raise HTTPException(status_code=400, detail="Uploaded SRT file was empty.")
+
+    job_id = str(uuid.uuid4())
+    generation_config = _load_generation_config(config)
+
+    with _tasks_lock:
+        _tasks[job_id] = {"status": "queued", "progress": 0.0, "message": "Waiting to start"}
+
+    background_tasks.add_task(_process_generation, job_id, srt_payload, generation_config)
+    return JSONResponse({"job_id": job_id})
+
+
+@app.post("/transcribe")
+async def transcribe_audio(
+    file: UploadFile = File(...),
+    config: Optional[str] = Form(None),
+) -> JSONResponse:
+    """Generate a metadata-rich subtitle file from an uploaded audio clip."""
+
+    audio_payload = await file.read()
+    if not audio_payload:
+        raise HTTPException(status_code=400, detail="Uploaded音频文件为空。")
+
+    recognizer = _load_recognizer(config)
+    segments = recognizer.transcribe(audio_payload, file.filename or "audio.mp3")
+    if not segments:
+        raise HTTPException(status_code=400, detail="识别接口未返回有效的字幕片段。")
+
+    srt_text = segments_to_srt(segments)
+    transcript_id = str(uuid.uuid4())
+    metadata = _save_transcript(
+        transcript_id,
+        file.filename or "audio.mp3",
+        srt_text,
+        serialize_segments(segments),
+    )
+
+    return JSONResponse(
+        {
+            "transcript_id": transcript_id,
+            "download_url": f"/transcripts/{transcript_id}/download",
+            "metadata": metadata,
+            "srt": srt_text,
+        }
+    )
+
+
+@app.get("/transcripts")
+async def list_transcripts() -> JSONResponse:
+    return JSONResponse({"transcripts": _list_transcripts()})
+
+
+@app.get("/transcripts/{transcript_id}")
+async def get_transcript(transcript_id: str) -> JSONResponse:
+    metadata = _load_transcript_metadata(transcript_id)
+    srt_text = _load_transcript_srt(transcript_id)
+    metadata["download_url"] = f"/transcripts/{transcript_id}/download"
+    metadata["srt"] = srt_text
+    return JSONResponse(metadata)
+
+
+@app.get("/transcripts/{transcript_id}/download")
+async def download_transcript(transcript_id: str) -> FileResponse:
+    srt_path = _transcript_file_path(transcript_id)
+    if not srt_path.exists():
+        raise HTTPException(status_code=404, detail="Transcript not found")
+    return FileResponse(
+        srt_path,
+        media_type="application/x-subrip",
+        filename=f"transcript-{transcript_id}.srt",
+    )
+
+
+@app.post("/transcripts/{transcript_id}/generate")
+async def generate_from_transcript(
+    transcript_id: str,
+    background_tasks: BackgroundTasks,
+    config: str = Form(...),
+) -> JSONResponse:
+    srt_text = _load_transcript_srt(transcript_id)
+
+    job_id = str(uuid.uuid4())
+    generation_config = _load_generation_config(config)
+
+    with _tasks_lock:
+        _tasks[job_id] = {"status": "queued", "progress": 0.0, "message": "Waiting to start"}
+
+    background_tasks.add_task(_process_generation, job_id, srt_text.encode("utf-8"), generation_config)
+    return JSONResponse({"job_id": job_id})
+
+
+@app.get("/status/{job_id}")
+async def job_status(job_id: str) -> JSONResponse:
+    with _tasks_lock:
+        task = _tasks.get(job_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return JSONResponse(task)
+
+
+@app.get("/download/{job_id}")
+async def download(job_id: str) -> FileResponse:
+    output_path = GENERATED_DIR / f"{job_id}.mp3"
+    if not output_path.exists():
+        raise HTTPException(status_code=404, detail="Generated audio not found")
+    return FileResponse(
+        output_path,
+        media_type="audio/mpeg",
+        filename=f"voiceover-{job_id}.mp3",
+    )
+
+
+__all__ = ["app"]

--- a/apps/srt_voice_service/services/audio_stitcher.py
+++ b/apps/srt_voice_service/services/audio_stitcher.py
@@ -1,0 +1,53 @@
+"""Utilities for combining voice segments into a single timeline."""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+from datetime import timedelta
+from pathlib import Path
+from typing import List, Tuple
+
+from pydub import AudioSegment
+
+from .srt_parser import SubtitleSegment
+
+
+@dataclass(slots=True)
+class ExportedAudio:
+    """Details about a rendered audio file."""
+
+    path: Path
+    duration_seconds: float
+
+
+class AudioTimelineBuilder:
+    """Accumulates subtitle-aligned audio segments and mixes them into a single file."""
+
+    def __init__(self) -> None:
+        self._entries: List[Tuple[SubtitleSegment, AudioSegment]] = []
+
+    def add_segment(self, subtitle: SubtitleSegment, audio_bytes: bytes, audio_format: str) -> None:
+        """Add an audio clip aligned with a subtitle segment."""
+
+        if not audio_bytes:
+            raise ValueError("Received empty audio payload from provider.")
+        segment = AudioSegment.from_file(io.BytesIO(audio_bytes), format=audio_format)
+        self._entries.append((subtitle, segment))
+
+    def export(self, output_path: Path) -> ExportedAudio:
+        if not self._entries:
+            raise ValueError("No audio segments were added to the timeline.")
+
+        total_duration = max(entry.end for entry, _ in self._entries)
+        buffer = timedelta(seconds=1)
+        total_ms = int((total_duration + buffer).total_seconds() * 1000)
+        timeline = AudioSegment.silent(duration=total_ms)
+
+        for subtitle, segment in self._entries:
+            start_ms = int(subtitle.start.total_seconds() * 1000)
+            timeline = timeline.overlay(segment, position=start_ms)
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        timeline.export(output_path, format="mp3")
+        return ExportedAudio(path=output_path, duration_seconds=timeline.duration_seconds)

--- a/apps/srt_voice_service/services/config.py
+++ b/apps/srt_voice_service/services/config.py
@@ -1,0 +1,118 @@
+"""Configuration models for the SRT voice generation service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Mapping, Optional
+
+
+@dataclass(slots=True)
+class ProviderConfig:
+    """Configuration for the third-party text-to-speech provider."""
+
+    base_url: str
+    api_key: Optional[str] = None
+    timeout_seconds: float = 30.0
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, object]) -> "ProviderConfig":
+        base_url = str(payload.get("base_url", "")).strip()
+        if not base_url:
+            raise ValueError("Provider configuration requires a 'base_url'.")
+        api_key = payload.get("api_key")
+        timeout = float(payload.get("timeout_seconds", 30.0))
+        return cls(base_url=base_url, api_key=str(api_key) if api_key else None, timeout_seconds=timeout)
+
+
+@dataclass(slots=True)
+class RoleConfig:
+    """Voice configuration for a single speaker."""
+
+    voice_id: str
+    audio_format: str = "mp3"
+    speaking_rate: float = 1.0
+    pitch: float = 0.0
+    gender: Optional[str] = None
+    extra: Dict[str, object] = field(default_factory=dict)
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, object]) -> "RoleConfig":
+        voice_id = str(payload.get("voice_id", "")).strip()
+        if not voice_id:
+            raise ValueError("Each role must define a non-empty 'voice_id'.")
+        audio_format = str(payload.get("audio_format", "mp3"))
+        speaking_rate = float(payload.get("speaking_rate", 1.0))
+        pitch = float(payload.get("pitch", 0.0))
+        gender_value = payload.get("gender")
+        gender = str(gender_value).strip() if gender_value else None
+        extra = {
+            key: value
+            for key, value in payload.items()
+            if key
+            not in {"voice_id", "audio_format", "speaking_rate", "pitch", "gender"}
+        }
+        return cls(
+            voice_id=voice_id,
+            audio_format=audio_format,
+            speaking_rate=speaking_rate,
+            pitch=pitch,
+            gender=gender,
+            extra=extra,
+        )
+
+
+@dataclass(slots=True)
+class GenerationConfig:
+    """Aggregate configuration used during a voice generation job."""
+
+    roles: Dict[str, RoleConfig]
+    provider: Optional[ProviderConfig] = None
+    gender_roles: Dict[str, RoleConfig] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> "GenerationConfig":
+        raw_roles = payload.get("roles")
+        if not isinstance(raw_roles, Mapping):
+            raise ValueError("Configuration must contain a 'roles' mapping of speaker names to settings.")
+
+        roles = {name: RoleConfig.from_mapping(config) for name, config in raw_roles.items()}
+
+        gender_roles: Dict[str, RoleConfig] = {}
+        raw_gender_roles = payload.get("gender_roles")
+        if isinstance(raw_gender_roles, Mapping):
+            for gender_key, config in raw_gender_roles.items():
+                if not isinstance(config, Mapping):
+                    continue
+                normalized_gender = str(gender_key).strip().lower()
+                if not normalized_gender:
+                    continue
+                gender_roles[normalized_gender] = RoleConfig.from_mapping(config)
+                gender_roles[normalized_gender].gender = normalized_gender
+
+        provider_config: Optional[ProviderConfig] = None
+        raw_provider = payload.get("provider")
+        if isinstance(raw_provider, Mapping):
+            base_url = str(raw_provider.get("base_url", "")).strip()
+            if base_url:
+                provider_config = ProviderConfig.from_mapping(raw_provider)
+
+        return cls(roles=roles, provider=provider_config, gender_roles=gender_roles)
+
+    def resolve_role(self, speaker: str, gender: Optional[str]) -> RoleConfig:
+        """Return the best matching role configuration for the supplied speaker."""
+
+        if speaker in self.roles:
+            return self.roles[speaker]
+
+        normalized_gender = (gender or "").strip().lower()
+        if normalized_gender:
+            for role in self.roles.values():
+                if role.gender and role.gender.strip().lower() == normalized_gender:
+                    return role
+            if normalized_gender in self.gender_roles:
+                return self.gender_roles[normalized_gender]
+
+        raise ValueError(
+            f"No voice configuration found for speaker '{speaker}'. "
+            "Please add a mapping in the role configuration or provide a matching gender role."
+        )

--- a/apps/srt_voice_service/services/speech_recognizer.py
+++ b/apps/srt_voice_service/services/speech_recognizer.py
@@ -1,0 +1,162 @@
+"""Speech recognition service abstractions."""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Iterable, List
+
+import requests
+import srt
+
+from .config import ProviderConfig
+
+
+@dataclass(slots=True)
+class RecognizedSegment:
+    """Represents a single transcription result from the recognizer."""
+
+    speaker: str
+    text: str
+    start: timedelta
+    end: timedelta
+    emotion: str | None = None
+    tone: str | None = None
+    gender: str | None = None
+
+
+class SpeechRecognizer:
+    """Abstract base class for audio transcription providers."""
+
+    def transcribe(self, audio_bytes: bytes, filename: str) -> List[RecognizedSegment]:
+        raise NotImplementedError
+
+
+class ThirdPartySpeechRecognizer(SpeechRecognizer):
+    """Calls an external HTTP API to transcribe audio."""
+
+    def __init__(self, config: ProviderConfig) -> None:
+        self._config = config
+
+    def transcribe(self, audio_bytes: bytes, filename: str) -> List[RecognizedSegment]:
+        files = {"file": (filename, io.BytesIO(audio_bytes), "audio/mpeg")}
+        headers = {}
+        if self._config.api_key:
+            headers["Authorization"] = f"Bearer {self._config.api_key}"
+
+        response = requests.post(
+            self._config.base_url.rstrip("/") + "/transcribe",
+            files=files,
+            headers=headers,
+            timeout=self._config.timeout_seconds,
+        )
+        if response.status_code >= 400:
+            raise RuntimeError(
+                f"Speech recognizer returned HTTP {response.status_code}: {response.text}"
+            )
+
+        payload = response.json()
+        segments_payload = payload.get("segments")
+        if not isinstance(segments_payload, list):
+            raise RuntimeError("Recognizer response did not include a 'segments' list.")
+
+        segments: List[RecognizedSegment] = []
+        for entry in segments_payload:
+            if not isinstance(entry, dict):
+                continue
+            start_seconds = float(entry.get("start", 0))
+            end_seconds = float(entry.get("end", start_seconds))
+            segments.append(
+                RecognizedSegment(
+                    speaker=str(entry.get("speaker", "Narrator")),
+                    text=str(entry.get("text", "")).strip(),
+                    start=timedelta(seconds=start_seconds),
+                    end=timedelta(seconds=end_seconds),
+                    emotion=(str(entry.get("emotion")).strip() or None)
+                    if entry.get("emotion")
+                    else None,
+                    tone=(str(entry.get("tone")).strip() or None)
+                    if entry.get("tone")
+                    else None,
+                    gender=(str(entry.get("gender")).strip() or None)
+                    if entry.get("gender")
+                    else None,
+                )
+            )
+        return segments
+
+
+class MockSpeechRecognizer(SpeechRecognizer):
+    """Generates a deterministic transcription for development environments."""
+
+    def transcribe(self, audio_bytes: bytes, filename: str) -> List[RecognizedSegment]:  # noqa: ARG002
+        base_duration = max(len(audio_bytes) / 32000, 6.0)
+        half = base_duration / 2
+        return [
+            RecognizedSegment(
+                speaker="Alice",
+                text="大家好，欢迎收听今天的节目！",
+                start=timedelta(seconds=0),
+                end=timedelta(seconds=half * 0.8),
+                emotion="happy",
+                tone="warm",
+                gender="female",
+            ),
+            RecognizedSegment(
+                speaker="Bob",
+                text="我是联合主持人，我们将讨论语音合成的新功能。",
+                start=timedelta(seconds=half * 0.8),
+                end=timedelta(seconds=base_duration),
+                emotion="excited",
+                tone="energetic",
+                gender="male",
+            ),
+        ]
+
+
+def segments_to_srt(segments: Iterable[RecognizedSegment]) -> str:
+    """Compose recognised segments into an SRT string with metadata tags."""
+
+    subtitles = []
+    for index, segment in enumerate(segments, start=1):
+        metadata_parts = []
+        if segment.emotion:
+            metadata_parts.append(f"emotion={segment.emotion}")
+        if segment.tone:
+            metadata_parts.append(f"tone={segment.tone}")
+        if segment.gender:
+            metadata_parts.append(f"gender={segment.gender}")
+        speaker = segment.speaker or "Narrator"
+        if metadata_parts:
+            speaker = "|".join([speaker] + metadata_parts)
+        content = f"{speaker}: {segment.text}"
+        subtitles.append(
+            srt.Subtitle(
+                index=index,
+                start=segment.start,
+                end=segment.end,
+                content=content,
+            )
+        )
+    return srt.compose(subtitles)
+
+
+def serialize_segments(segments: Iterable[RecognizedSegment]) -> list[dict[str, object]]:
+    """Serialize transcription segments into JSON serialisable dictionaries."""
+
+    serialised: list[dict[str, object]] = []
+    for segment in segments:
+        serialised.append(
+            {
+                "speaker": segment.speaker,
+                "text": segment.text,
+                "start": segment.start.total_seconds(),
+                "end": segment.end.total_seconds(),
+                "emotion": segment.emotion,
+                "tone": segment.tone,
+                "gender": segment.gender,
+            }
+        )
+    return serialised
+

--- a/apps/srt_voice_service/services/srt_parser.py
+++ b/apps/srt_voice_service/services/srt_parser.py
@@ -1,0 +1,67 @@
+"""Utilities for parsing SRT subtitle files."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Iterator
+
+import srt
+
+
+@dataclass(slots=True)
+class SubtitleSegment:
+    """Lightweight representation of a single SRT cue."""
+
+    speaker: str
+    text: str
+    start: timedelta
+    end: timedelta
+    emotion: str | None = None
+    tone: str | None = None
+    gender: str | None = None
+
+
+def _split_speaker_and_text(payload: str) -> tuple[str, str, dict[str, str]]:
+    if ":" in payload:
+        potential_speaker, remainder = payload.split(":", 1)
+        speaker_token = potential_speaker.strip()
+        metadata: dict[str, str] = {}
+
+        if "|" in speaker_token:
+            parts = [part.strip() for part in speaker_token.split("|") if part.strip()]
+            if parts:
+                speaker = parts[0]
+                for meta_part in parts[1:]:
+                    if "=" not in meta_part:
+                        continue
+                    key, value = meta_part.split("=", 1)
+                    metadata[key.strip().lower()] = value.strip()
+            else:
+                speaker = "Narrator"
+        else:
+            speaker = speaker_token
+
+        if not speaker:
+            speaker = "Narrator"
+        return speaker, remainder.strip(), metadata
+    return "Narrator", payload.strip(), {}
+
+
+def parse_srt(raw_content: str) -> Iterator[SubtitleSegment]:
+    """Yield subtitle segments from raw SRT content."""
+
+    for entry in srt.parse(raw_content):
+        text = entry.content.strip()
+        if not text:
+            continue
+        speaker, content, metadata = _split_speaker_and_text(text)
+        yield SubtitleSegment(
+            speaker=speaker,
+            text=content,
+            start=entry.start,
+            end=entry.end,
+            emotion=metadata.get("emotion"),
+            tone=metadata.get("tone"),
+            gender=metadata.get("gender"),
+        )

--- a/apps/srt_voice_service/services/voice_provider.py
+++ b/apps/srt_voice_service/services/voice_provider.py
@@ -1,0 +1,83 @@
+"""Voice provider interfaces used for synthesizing speech."""
+
+from __future__ import annotations
+
+import base64
+import io
+from abc import ABC, abstractmethod
+from typing import Dict
+
+import requests
+from pydub.generators import Sine
+
+from .config import ProviderConfig, RoleConfig
+
+
+class VoiceProvider(ABC):
+    """Abstract base class for text-to-speech providers."""
+
+    @abstractmethod
+    def synthesize(self, text: str, role: RoleConfig) -> bytes:
+        """Generate audio bytes for the supplied text."""
+
+
+class ThirdPartyVoiceProvider(VoiceProvider):
+    """Calls an external HTTP API to synthesize speech."""
+
+    def __init__(self, config: ProviderConfig) -> None:
+        self._config = config
+
+    def synthesize(self, text: str, role: RoleConfig) -> bytes:
+        payload: Dict[str, object] = {
+            "voice_id": role.voice_id,
+            "text": text,
+            "speaking_rate": role.speaking_rate,
+            "pitch": role.pitch,
+        }
+        if role.gender:
+            payload["gender"] = role.gender
+        payload.update(role.extra)
+
+        headers = {"Content-Type": "application/json"}
+        if self._config.api_key:
+            headers["Authorization"] = f"Bearer {self._config.api_key}"
+
+        response = requests.post(
+            self._config.base_url.rstrip("/") + "/synthesize",
+            json=payload,
+            headers=headers,
+            timeout=self._config.timeout_seconds,
+        )
+        if response.status_code >= 400:
+            raise RuntimeError(
+                f"Voice provider returned HTTP {response.status_code}: {response.text}"
+            )
+
+        content_type = response.headers.get("Content-Type", "")
+        if content_type.startswith("application/json"):
+            body = response.json()
+            audio_payload = body.get("audio")
+            if not isinstance(audio_payload, str):
+                raise RuntimeError("Voice provider JSON response did not contain 'audio' field.")
+            return base64.b64decode(audio_payload)
+
+        return response.content
+
+
+class MockVoiceProvider(VoiceProvider):
+    """Generates placeholder audio tones for development environments."""
+
+    def synthesize(self, text: str, role: RoleConfig) -> bytes:
+        words = max(len(text.split()), 1)
+        duration_ms = max(350, words * 320)
+        frequency = 300 + (abs(hash(role.voice_id)) % 300)
+        segment = (
+            Sine(frequency)
+            .to_audio_segment(duration=duration_ms)
+            .fade_in(40)
+            .fade_out(80)
+        )
+        buffer = io.BytesIO()
+        export_format = role.audio_format or "mp3"
+        segment.export(buffer, format=export_format)
+        return buffer.getvalue()

--- a/apps/srt_voice_service/static/app.js
+++ b/apps/srt_voice_service/static/app.js
@@ -1,0 +1,253 @@
+const generationForm = document.getElementById("generation-form");
+const transcriptionForm = document.getElementById("transcription-form");
+const transcriptsList = document.getElementById("transcripts-list");
+const transcriptSelect = document.getElementById("transcript-select");
+const selectedTranscriptInput = document.getElementById("selected-transcript-id");
+const transcriptionResult = document.getElementById("transcription-result");
+const transcriptionMessage = document.getElementById("transcription-message");
+const transcriptViewer = document.getElementById("transcript-viewer");
+
+const statusPanel = document.getElementById("status-panel");
+const progressBar = document.getElementById("progress-bar");
+const statusMessage = document.getElementById("status-message");
+const downloadLink = document.getElementById("download-link");
+
+let pollTimer = null;
+
+function resetStatus() {
+  if (pollTimer) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
+  progressBar.style.width = "0%";
+  statusMessage.textContent = "";
+  downloadLink.classList.add("hidden");
+  downloadLink.innerHTML = "";
+}
+
+async function pollStatus(jobId) {
+  pollTimer = setInterval(async () => {
+    try {
+      const response = await fetch(`/status/${jobId}`);
+      if (!response.ok) {
+        throw new Error("无法获取任务状态");
+      }
+      const data = await response.json();
+      progressBar.style.width = `${Math.floor(data.progress || 0)}%`;
+      statusMessage.textContent = data.message || "处理中";
+
+      if (data.status === "completed") {
+        clearInterval(pollTimer);
+        pollTimer = null;
+        if (data.download_url) {
+          downloadLink.innerHTML = `<a href="${data.download_url}" download>下载生成的 MP3</a>`;
+          downloadLink.classList.remove("hidden");
+        }
+      } else if (data.status === "failed") {
+        clearInterval(pollTimer);
+        pollTimer = null;
+        statusMessage.textContent = `任务失败：${data.message || "未知错误"}`;
+      }
+    } catch (error) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+      statusMessage.textContent = `状态更新失败：${error.message}`;
+    }
+  }, 1500);
+}
+
+function renderTranscripts(transcripts) {
+  transcriptsList.innerHTML = "";
+
+  if (!transcripts.length) {
+    transcriptsList.innerHTML = "<p>暂无字幕文件，您可以先上传音频进行识别。</p>";
+    return;
+  }
+
+  transcripts.forEach((item) => {
+    const article = document.createElement("article");
+    const createdAt = item.created_at ? new Date(item.created_at).toLocaleString() : "";
+    const speakers = item.speakers && item.speakers.length ? item.speakers.join("、") : "未识别";
+    const duration = item.duration_seconds ? `${item.duration_seconds.toFixed(1)}s` : "-";
+
+    article.innerHTML = `
+      <header>
+        <strong>${item.original_filename || item.id}</strong>
+      </header>
+      <p>创建时间：${createdAt}</p>
+      <p>角色：${speakers}</p>
+      <p>时长：${duration}</p>
+      <footer class="grid">
+        <a class="secondary" href="${item.download_url}" download>下载 SRT</a>
+        <button type="button" data-action="view" data-id="${item.id}">查看内容</button>
+        <button type="button" data-action="use" data-id="${item.id}">用于语音合成</button>
+      </footer>
+    `;
+    transcriptsList.appendChild(article);
+  });
+}
+
+function updateTranscriptSelect(transcripts) {
+  const previousValue = transcriptSelect.value;
+  transcriptSelect.innerHTML = '<option value="">-- 请选择已有字幕 --</option>';
+
+  transcripts.forEach((item) => {
+    const option = document.createElement("option");
+    option.value = item.id;
+    const createdAt = item.created_at ? new Date(item.created_at).toLocaleString() : "";
+    option.textContent = `${item.original_filename || item.id} (${createdAt})`;
+    transcriptSelect.appendChild(option);
+  });
+
+  if (previousValue) {
+    transcriptSelect.value = previousValue;
+  }
+  selectedTranscriptInput.value = transcriptSelect.value;
+}
+
+async function fetchTranscripts() {
+  try {
+    const response = await fetch("/transcripts");
+    if (!response.ok) {
+      throw new Error("接口返回异常");
+    }
+    const data = await response.json();
+    const transcripts = data.transcripts || [];
+    renderTranscripts(transcripts);
+    updateTranscriptSelect(transcripts);
+  } catch (error) {
+    transcriptsList.innerHTML = `<p class="contrast">加载字幕列表失败：${error.message}</p>`;
+    transcriptSelect.innerHTML = '<option value="">-- 请选择已有字幕 --</option>';
+  }
+}
+
+transcriptsList.addEventListener("click", async (event) => {
+  const target = event.target.closest("button[data-action]");
+  if (!target) {
+    return;
+  }
+
+  const action = target.dataset.action;
+  const transcriptId = target.dataset.id;
+
+  if (!action || !transcriptId) {
+    return;
+  }
+
+  if (action === "view") {
+    try {
+      const response = await fetch(`/transcripts/${transcriptId}`);
+      if (!response.ok) {
+        throw new Error("无法获取字幕内容");
+      }
+      const data = await response.json();
+      transcriptionResult.classList.remove("hidden");
+      transcriptionMessage.innerHTML = `来源：${data.original_filename || data.id}，<a href="${data.download_url}" download>下载</a>`;
+      transcriptViewer.textContent = data.srt || "";
+      selectedTranscriptInput.value = transcriptId;
+      transcriptSelect.value = transcriptId;
+    } catch (error) {
+      transcriptionResult.classList.remove("hidden");
+      transcriptionMessage.textContent = `加载失败：${error.message}`;
+      transcriptViewer.textContent = "";
+    }
+  } else if (action === "use") {
+    selectedTranscriptInput.value = transcriptId;
+    transcriptSelect.value = transcriptId;
+    transcriptionResult.classList.remove("hidden");
+    transcriptionMessage.textContent = "已选择该字幕用于语音生成，请在下方配置参数并提交。";
+    transcriptViewer.textContent = "";
+    generationForm.scrollIntoView({ behavior: "smooth" });
+  }
+});
+
+transcriptSelect.addEventListener("change", (event) => {
+  selectedTranscriptInput.value = event.target.value;
+});
+
+transcriptionForm.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const formData = new FormData(transcriptionForm);
+  transcriptionResult.classList.remove("hidden");
+  transcriptionMessage.textContent = "正在上传并识别，请稍候...";
+  transcriptViewer.textContent = "";
+
+  try {
+    const response = await fetch("/transcribe", {
+      method: "POST",
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(errorText || "识别失败");
+    }
+
+    const data = await response.json();
+    transcriptionMessage.innerHTML = `字幕已生成，可 <a href="${data.download_url}" download>下载 SRT 文件</a>。`;
+    transcriptViewer.textContent = data.srt || "";
+    await fetchTranscripts();
+    transcriptSelect.value = data.transcript_id;
+    selectedTranscriptInput.value = data.transcript_id;
+  } catch (error) {
+    transcriptionMessage.textContent = `识别失败：${error.message}`;
+    transcriptViewer.textContent = "";
+  }
+});
+
+generationForm.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  resetStatus();
+
+  const fileInput = document.getElementById("srt-file");
+  const configInput = document.getElementById("config-json");
+  const transcriptId = transcriptSelect.value || selectedTranscriptInput.value;
+
+  if (!configInput.value.trim()) {
+    statusPanel.classList.remove("hidden");
+    statusMessage.textContent = "请填写角色与接口配置。";
+    return;
+  }
+
+  if (!fileInput.files.length && !transcriptId) {
+    statusPanel.classList.remove("hidden");
+    statusMessage.textContent = "请上传字幕文件或选择历史字幕。";
+    return;
+  }
+
+  statusPanel.classList.remove("hidden");
+  statusMessage.textContent = "正在创建语音生成任务...";
+
+  try {
+    let response;
+    if (fileInput.files.length) {
+      const formData = new FormData();
+      formData.append("file", fileInput.files[0]);
+      formData.append("config", configInput.value);
+      response = await fetch("/generate", {
+        method: "POST",
+        body: formData,
+      });
+    } else {
+      const formData = new FormData();
+      formData.append("config", configInput.value);
+      response = await fetch(`/transcripts/${encodeURIComponent(transcriptId)}/generate`, {
+        method: "POST",
+        body: formData,
+      });
+    }
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(errorText || "提交失败");
+    }
+
+    const data = await response.json();
+    statusMessage.textContent = "任务已创建，开始处理...";
+    pollStatus(data.job_id);
+  } catch (error) {
+    statusMessage.textContent = `提交失败：${error.message}`;
+  }
+});
+
+fetchTranscripts();

--- a/apps/srt_voice_service/templates/index.html
+++ b/apps/srt_voice_service/templates/index.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="zh">
+  <head>
+    <meta charset="UTF-8" />
+    <title>多角色语音合成</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css" />
+    <style>
+      body {
+        padding: 2rem;
+      }
+      textarea {
+        min-height: 200px;
+        font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+      }
+      #status-panel {
+        margin-top: 1.5rem;
+      }
+      .hidden {
+        display: none;
+      }
+      .progress-bar {
+        height: 12px;
+        background-color: var(--primary);
+        transition: width 0.3s ease;
+      }
+      .progress-track {
+        background-color: rgba(0, 0, 0, 0.1);
+        width: 100%;
+        height: 12px;
+        border-radius: 10px;
+        overflow: hidden;
+      }
+      footer {
+        margin-top: 3rem;
+        font-size: 0.9rem;
+        color: #555;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <h1>多角色语音播客生成器</h1>
+      <p>
+        上传音频或字幕文件，生成带有情绪、语气、性别标注的字幕，并可按角色配置语音接口生成自然流畅的多角色语音文件。
+      </p>
+
+      <section>
+        <h2>步骤 1：上传音频生成智能字幕</h2>
+        <form id="transcription-form">
+          <label for="audio-file">音频文件（MP3/WAV/M4A）</label>
+          <input type="file" id="audio-file" name="file" accept="audio/*" required />
+
+          <label for="transcription-config">识别服务配置（可选，JSON）</label>
+          <textarea
+            id="transcription-config"
+            name="config"
+            spellcheck="false"
+            placeholder='{"provider": {"base_url": "https://api.example.com/asr", "api_key": "TOKEN"}}'
+          ></textarea>
+
+          <button type="submit">生成字幕文件</button>
+        </form>
+        <article id="transcription-result" class="hidden">
+          <h3>最新生成的字幕</h3>
+          <p id="transcription-message"></p>
+          <pre id="transcript-viewer"></pre>
+        </article>
+      </section>
+
+      <section>
+        <h2>步骤 2：管理字幕资源</h2>
+        <p>下方列出所有已生成或上传的字幕文件，可查看、下载或继续用于语音合成。</p>
+        <div id="transcripts-list" class="grid"></div>
+      </section>
+
+      <section>
+        <h2>步骤 3：使用字幕生成语音</h2>
+        <form id="generation-form">
+          <fieldset>
+            <legend>选择字幕来源</legend>
+            <label for="srt-file">上传新的字幕文件（SRT）</label>
+            <input type="file" id="srt-file" name="file" accept=".srt" />
+
+            <label for="transcript-select">或选择历史字幕</label>
+            <select id="transcript-select">
+              <option value="">-- 请选择已有字幕 --</option>
+            </select>
+          </fieldset>
+
+          <label for="config-json">角色与接口配置（JSON，支持性别策略）</label>
+          <textarea id="config-json" name="config" spellcheck="false" required>{
+  "provider": {
+    "base_url": "https://api.example.com/tts",
+    "api_key": "YOUR_TOKEN"
+  },
+  "roles": {
+    "Alice": { "voice_id": "voice_a", "audio_format": "mp3", "gender": "female" },
+    "Bob": { "voice_id": "voice_b", "audio_format": "mp3", "gender": "male" }
+  },
+  "gender_roles": {
+    "female": { "voice_id": "general_female", "audio_format": "mp3" },
+    "male": { "voice_id": "general_male", "audio_format": "mp3" }
+  }
+}</textarea>
+
+          <input type="hidden" id="selected-transcript-id" name="transcript_id" />
+          <button type="submit">生成语音</button>
+        </form>
+      </section>
+
+      <section id="status-panel" class="hidden">
+        <h2>生成进度</h2>
+        <div class="progress-track">
+          <div id="progress-bar" class="progress-bar" style="width: 0%"></div>
+        </div>
+        <p id="status-message"></p>
+        <p id="download-link" class="hidden"></p>
+      </section>
+    </main>
+
+    <footer>
+      <p>提示：SRT 文本中可使用 <code>角色|emotion=高兴|tone=亲切|gender=female: 台词</code> 的格式添加情绪、语气与性别标签。</p>
+    </footer>
+
+    <script src="/static/app.js"></script>
+  </body>
+</html>

--- a/docs/srt_voice_service.md
+++ b/docs/srt_voice_service.md
@@ -1,0 +1,89 @@
+# 多角色字幕语音合成服务
+
+该服务提供一个简单的 Web 界面，可上传包含角色台词的 `.srt` 字幕文件或音频文件：
+
+- 支持调用第三方语音识别接口，将音频转写为带有情绪、语气与性别标签的字幕文件；
+- 可为不同角色配置语音合成参数，并按时间轴拼接为可下载的 MP3 文件。
+
+非常适合播客制作、视频配音或教学场景。
+
+## 功能概述
+
+- **音频转写**：上传 MP3/WAV 音频，通过第三方语音识别接口生成带情绪、语气、性别标注的字幕，并自动存档。
+- **SRT 解析**：自动识别字幕中的时间轴以及 `角色|emotion=开心|tone=温柔|gender=female: 对白` 这类富文本格式。
+- **多角色语音生成**：为每个角色配置不同的第三方语音合成参数；支持按角色或按性别匹配合成设置，未配置时使用内置的本地占位音频生成器。
+- **时间线拼接**：将单句语音片段按照字幕时间码对齐并合成完整音频。
+- **任务进度**：前端轮询后端任务状态，显示生成进度、状态说明与下载链接。
+- **字幕管理**：历史字幕文件可在线查看、下载，并一键重新触发语音合成。
+
+## 目录结构
+
+```text
+apps/srt_voice_service/
+├── app.py                 # FastAPI 入口
+├── services/
+│   ├── audio_stitcher.py  # 音频拼接工具
+│   ├── config.py          # 角色及服务端配置模型
+│   ├── srt_parser.py      # 字幕解析逻辑
+│   ├── speech_recognizer.py # 语音识别接口调用与占位实现
+│   └── voice_provider.py  # 第三方接口调用与本地占位实现
+├── static/
+│   └── app.js             # 前端交互脚本
+└── templates/
+    └── index.html         # Web UI
+```
+
+生成的 MP3 文件默认保存在 `apps/srt_voice_service/generated/` 目录中；识别得到的字幕文件及其元数据会存放在 `apps/srt_voice_service/transcripts/` 目录。
+
+## 运行步骤
+
+1. 安装依赖（确保已安装 `ffmpeg` 以便导出 MP3）：
+
+   ```bash
+   poetry install
+   ```
+
+2. 启动服务：
+
+   ```bash
+   uvicorn apps.srt_voice_service.app:app --reload
+   ```
+
+3. 访问 `http://127.0.0.1:8000`，按步骤上传音频生成字幕或直接上传 SRT，随后配置角色参数触发语音合成。
+
+## 配置说明
+
+- **provider.base_url**：第三方语音合成接口的基础 URL，服务会在其后追加 `/synthesize` 路径。
+- **provider.api_key**：若接口需要鉴权，服务会以 `Bearer` 方式写入 `Authorization` 请求头。
+- **roles**：以角色名为键，配置 `voice_id`、语速、音调及可选的 `gender` 字段，其余字段会透传给第三方接口。
+- **gender_roles**：按性别（`female` / `male` 等自定义标签）定义默认语音，当字幕中出现匹配的性别标签且未显式配置同名角色时将自动应用。
+
+示例：
+
+```json
+{
+  "provider": {
+    "base_url": "https://api.example.com/tts",
+    "api_key": "YOUR_TOKEN"
+  },
+  "roles": {
+    "Alice": { "voice_id": "voice_a", "gender": "female", "speaking_rate": 1.05 },
+    "Bob": { "voice_id": "voice_b", "gender": "male", "pitch": -1.5 }
+  },
+  "gender_roles": {
+    "female": { "voice_id": "generic_female" },
+    "male": { "voice_id": "generic_male" }
+  }
+}
+```
+
+当未提供 `provider.base_url` 时，后端会使用 `MockVoiceProvider` 生成占位音频，便于快速预览时间轴与拼接效果。
+
+若语音识别配置中未指定第三方接口，同样会使用内置的 `MockSpeechRecognizer` 返回示例字幕，便于端到端联调。
+
+## 注意事项
+
+- SRT 台词需采用 `角色名: 内容` 的格式才能正确识别说话人。
+- 第三方接口返回的内容可以是 MP3 等音频二进制流，或包含 Base64 字段的 JSON 数据。
+- 若使用自定义音频格式，务必在角色配置中通过 `audio_format` 指定对应的格式，以便正确解析。
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,13 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
+fastapi = "^0.110.0"
+jinja2 = "^3.1.3"
+pydub = "^0.25.1"
+python-multipart = "^0.0.9"
+requests = "^2.31.0"
+srt = "^3.5.3"
+uvicorn = {extras = ["standard"], version = "^0.27.1"}
 
 
 [build-system]


### PR DESCRIPTION
## Summary
- add speech recognition utilities and FastAPI endpoints to upload audio, persist transcripts with metadata, and regenerate voiceovers from saved subtitles
- enhance configuration parsing to support gender-aware role matching and reuse for historical subtitles during synthesis
- expand the web UI and documentation to manage transcript lists, preview subtitles, and trigger new voice generation jobs with gender role presets

## Testing
- python -m compileall apps/srt_voice_service

------
https://chatgpt.com/codex/tasks/task_e_68d8a559bfe08332ad1dbe63ef1cd2bd