### PR TITLE
Add index-tts text-to-speech provider

### DIFF
--- a/autogpts/autogpt/autogpt/config/config.py
+++ b/autogpts/autogpt/autogpt/config/config.py
@@ -296,6 +296,24 @@ class ConfigBuilder(Configurable[Config]):
                 "api_key": os.getenv("ELEVENLABS_API_KEY"),
                 "voice_id": os.getenv("ELEVENLABS_VOICE_ID", ""),
             }
+        index_tts_settings: dict[str, object] = {}
+        if os.getenv("INDEX_TTS_URL"):
+            index_tts_settings["base_url"] = os.getenv("INDEX_TTS_URL")
+        if os.getenv("INDEX_TTS_ENDPOINT"):
+            index_tts_settings["endpoint"] = os.getenv("INDEX_TTS_ENDPOINT")
+        if os.getenv("INDEX_TTS_VOICE"):
+            index_tts_settings["voice"] = os.getenv("INDEX_TTS_VOICE")
+        if os.getenv("INDEX_TTS_LANGUAGE"):
+            index_tts_settings["language"] = os.getenv("INDEX_TTS_LANGUAGE")
+        if os.getenv("INDEX_TTS_AUDIO_FORMAT"):
+            index_tts_settings["audio_format"] = os.getenv("INDEX_TTS_AUDIO_FORMAT")
+        if os.getenv("INDEX_TTS_TIMEOUT"):
+            with contextlib.suppress(ValueError):
+                index_tts_settings["request_timeout"] = float(
+                    os.getenv("INDEX_TTS_TIMEOUT", "")
+                )
+        if index_tts_settings:
+            config_dict["tts_config"]["index_tts"] = index_tts_settings
         if os.getenv("STREAMELEMENTS_VOICE"):
             config_dict["tts_config"]["streamelements"] = {
                 "voice": os.getenv("STREAMELEMENTS_VOICE"),
@@ -306,6 +324,8 @@ class ConfigBuilder(Configurable[Config]):
                 default_tts_provider = "macos"
             elif "elevenlabs" in config_dict["tts_config"]:
                 default_tts_provider = "elevenlabs"
+            elif "index_tts" in config_dict["tts_config"]:
+                default_tts_provider = "index"
             elif os.getenv("USE_BRIAN_TTS"):
                 default_tts_provider = "streamelements"
             else:

--- a/autogpts/autogpt/autogpt/speech/index_tts.py
+++ b/autogpts/autogpt/autogpt/speech/index_tts.py
@@ -1,0 +1,80 @@
+"""Text-to-speech provider that integrates the `index-tts` project."""
+from __future__ import annotations
+
+import contextlib
+import logging
+import tempfile
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urljoin
+
+import requests
+from playsound import playsound
+
+from autogpt.core.configuration import SystemConfiguration, UserConfigurable
+from autogpt.speech.base import VoiceBase
+
+logger = logging.getLogger(__name__)
+
+
+class IndexTTSConfig(SystemConfiguration):
+    """Configuration options for the local index-tts server."""
+
+    base_url: str = UserConfigurable(default="http://localhost:8080")
+    endpoint: str = UserConfigurable(default="/api/tts")
+    voice: Optional[str] = UserConfigurable(default=None)
+    language: Optional[str] = UserConfigurable(default=None)
+    audio_format: str = UserConfigurable(default="mp3")
+    request_timeout: float = UserConfigurable(default=60.0)
+
+
+class IndexTTSSpeech(VoiceBase):
+    """Use an index-tts instance that is running locally to synthesise audio."""
+
+    def _setup(self, config: Optional[IndexTTSConfig]) -> None:
+        self.config = config or IndexTTSConfig()
+
+    def _speech(self, text: str, _: int = 0) -> bool:
+        """Send text to the local index-tts server and play the resulting audio."""
+
+        base = self.config.base_url.rstrip("/") + "/"
+        endpoint = self.config.endpoint.lstrip("/")
+        url = urljoin(base, endpoint)
+        payload: dict[str, str] = {"text": text}
+        if self.config.voice:
+            payload["voice"] = self.config.voice
+        if self.config.language:
+            payload["language"] = self.config.language
+        if self.config.audio_format:
+            payload["format"] = self.config.audio_format
+
+        try:
+            response = requests.post(url, json=payload, timeout=self.config.request_timeout)
+        except requests.RequestException:
+            logger.exception("Failed to reach the index-tts server at %s", url)
+            return False
+
+        if response.status_code != 200:
+            logger.error(
+                "index-tts returned a non-success status: %s - %s",
+                response.status_code,
+                response.text,
+            )
+            return False
+
+        suffix = f".{self.config.audio_format}" if self.config.audio_format else ".mp3"
+        try:
+            with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as temp_audio:
+                temp_audio.write(response.content)
+                temp_audio_path = Path(temp_audio.name)
+
+            playsound(str(temp_audio_path), True)
+        except Exception:  # noqa: BLE001 - playsound can raise different platform specific errors
+            logger.exception("Unable to play audio returned by index-tts")
+            return False
+        finally:
+            with contextlib.suppress(OSError):
+                if "temp_audio_path" in locals() and temp_audio_path.exists():
+                    temp_audio_path.unlink()
+
+        return True

--- a/autogpts/autogpt/autogpt/speech/say.py
+++ b/autogpts/autogpt/autogpt/speech/say.py
@@ -10,6 +10,7 @@ from autogpt.core.configuration.schema import SystemConfiguration, UserConfigura
 from .base import VoiceBase
 from .eleven_labs import ElevenLabsConfig, ElevenLabsSpeech
 from .gtts import GTTSVoice
+from .index_tts import IndexTTSConfig, IndexTTSSpeech
 from .macos_tts import MacOSTTS
 from .stream_elements_speech import StreamElementsConfig, StreamElementsSpeech
 
@@ -21,9 +22,14 @@ _QUEUE_SEMAPHORE = Semaphore(
 class TTSConfig(SystemConfiguration):
     speak_mode: bool = False
     provider: Literal[
-        "elevenlabs", "gtts", "macos", "streamelements"
+        "elevenlabs",
+        "gtts",
+        "index",
+        "macos",
+        "streamelements",
     ] = UserConfigurable(default="gtts")
     elevenlabs: Optional[ElevenLabsConfig] = None
+    index_tts: Optional[IndexTTSConfig] = None
     streamelements: Optional[StreamElementsConfig] = None
 
 
@@ -53,6 +59,8 @@ class TextToSpeechProvider:
         tts_provider = config.provider
         if tts_provider == "elevenlabs":
             voice_engine = ElevenLabsSpeech(config.elevenlabs)
+        elif tts_provider == "index":
+            voice_engine = IndexTTSSpeech(config.index_tts)
         elif tts_provider == "macos":
             voice_engine = MacOSTTS()
         elif tts_provider == "streamelements":

--- a/docs/content/configuration/options.md
+++ b/docs/content/configuration/options.md
@@ -46,8 +46,14 @@ Configuration is controlled through the `Config` object. You can set configurati
 - `SHELL_DENYLIST`: List of shell commands that ARE NOT allowed to be executed by AutoGPT. Only applies if `SHELL_COMMAND_CONTROL` is set to `denylist`. Default: sudo,su
 - `SMART_LLM`: LLM Model to use for "smart" tasks. Default: gpt-4
 - `STREAMELEMENTS_VOICE`: StreamElements voice to use. Default: Brian
+- `INDEX_TTS_URL`: Base URL for a local [index-tts](https://github.com/index-tts/index-tts) service. Default: http://localhost:8080
+- `INDEX_TTS_ENDPOINT`: API endpoint path exposed by the index-tts service. Default: /api/tts
+- `INDEX_TTS_VOICE`: Preferred voice identifier to request from index-tts. Optional.
+- `INDEX_TTS_LANGUAGE`: Language code to request from index-tts. Optional.
+- `INDEX_TTS_AUDIO_FORMAT`: Audio format requested from index-tts (for example `mp3` or `wav`). Default: mp3
+- `INDEX_TTS_TIMEOUT`: Request timeout (in seconds) when calling index-tts. Default: 60
 - `TEMPERATURE`: Value of temperature given to OpenAI. Value from 0 to 2. Lower is more deterministic, higher is more random. See https://platform.openai.com/docs/api-reference/completions/create#completions/create-temperature
-- `TEXT_TO_SPEECH_PROVIDER`: Text to Speech Provider. Options are `gtts`, `macos`, `elevenlabs`, and `streamelements`. Default: gtts
+- `TEXT_TO_SPEECH_PROVIDER`: Text to Speech Provider. Options are `gtts`, `index`, `macos`, `elevenlabs`, and `streamelements`. Default: gtts
 - `USER_AGENT`: User-Agent given when browsing websites. Default: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36"
 - `USE_AZURE`: Use Azure's LLM Default: False
 - `USE_WEB_BROWSER`: Which web browser to use. Options are `chrome`, `firefox`, `safari` or `edge` Default: chrome


### PR DESCRIPTION
## Summary
- add an index-tts-based speech engine for local text-to-speech playback
- expose configuration wiring and environment variables for the new provider
- document how to enable the provider and configure the index-tts endpoint

## Testing
- python -m compileall autogpts/autogpt/autogpt/speech/index_tts.py
- python -m compileall autogpts/autogpt/autogpt/speech/say.py

------
https://chatgpt.com/codex/tasks/task_e_68f74ac7ecd483328c3eb2c663d220b6